### PR TITLE
ci(github-actions): create PRs when misspell detect spelling mistakes

### DIFF
--- a/.github/workflows/misspell.yaml
+++ b/.github/workflows/misspell.yaml
@@ -1,0 +1,15 @@
+name: Automatically create PRs for detected spelling mistakes.
+
+on:
+  push:
+
+jobs:
+  misspell:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: sobolevn/misspell-fixer-action@master
+      - uses: peter-evans/create-pull-request@v2.4.4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Leverage misspell to detect spelling mistakes and automatically create PRs for these issues. It
needs to be evaluated whether this should run on all pushes or only on master or PRs.

re #14